### PR TITLE
Specify the 'serve' command to the registry to match interface

### DIFF
--- a/registry/Dockerfile
+++ b/registry/Dockerfile
@@ -1,3 +1,3 @@
 FROM registry:2
-CMD ["/hooks-config.yml"]
+CMD ["serve", "/hooks-config.yml"]
 COPY ["./hooks-config.yml","/hooks-config.yml"]


### PR DESCRIPTION
registry is failing to start:

```
docker-compose up 
... snip ...
registry_1       | Error: unknown command "/hooks-config.yml"
registry_1       | Run 'registry help' for usage.
ch11notifications_registry_1 exited with code 0
```

resolve by specifying the `serve` command to registry:

```
docker-compose up -d --build
docker-compose logs registry | head -5
Attaching to ch11notifications_registry_1
registry_1       | time="2016-07-30T18:51:38.944392378Z" level=debug msg="using \"text\" logging formatter"
registry_1       | time="2016-07-30T18:51:38.945678544Z" level=info msg="debug server listening localhost:5001"
registry_1       | time="2016-07-30T18:51:38.946756359Z" level=info msg="configuring endpoint webhookmonitor (http://webhookmonitor:8000/), timeout=500ns, headers=map[]" environment=staging go.version=go1.6.1 instance.id=74239d4d-5ffc-4746-a189-2960051892d9 service=registry version=v2.4.0
registry_1       | time="2016-07-30T18:51:38.946819683Z" level=info msg="redis not configured" environment=staging go.version=go1.6.1 instance.id=74239d4d-5ffc-4746-a189-2960051892d9 service=registry version=v2.4.0
```

Resolves https://github.com/dockerinaction/ch11_notifications/issues/1
